### PR TITLE
Update minimum iOS support version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://skyway.ntt.com/ja/docs/user-guide/ios-sdk/
 - [SFU Bot ライブラリ](https://ios-sdk.api-reference.skyway.ntt.com/sfu)
 
 ### 対応OS
-iOS12+, iPadOS13+
+iOS14+, iPadOS14+
 
 ## License
 


### PR DESCRIPTION
# 概要
最低保証iOSバージョンを以下のように変更
- 変更前
  - iOS12+
  - iPadOS13+
- 変更後
  - iOS/iPadOS 14+